### PR TITLE
Fix alerts escaping and add noopener

### DIFF
--- a/resources/views/back/categories/form.blade.php
+++ b/resources/views/back/categories/form.blade.php
@@ -18,9 +18,9 @@
                 <x-back.validation-errors :errors="$errors" />
 
                 @if(session('ok'))
-                    <x-back.alert 
+                    <x-back.alert
                         type='success'
-                        title="{!! session('ok') !!}">
+                        title="{{ session('ok') }}">
                     </x-back.alert>
                 @endif
 

--- a/resources/views/back/comments/form.blade.php
+++ b/resources/views/back/comments/form.blade.php
@@ -14,9 +14,9 @@
                 <x-back.validation-errors :errors="$errors" />
 
                 @if(session('ok'))
-                    <x-back.alert 
+                    <x-back.alert
                         type='success'
-                        title="{!! session('ok') !!}">
+                        title="{{ session('ok') }}">
                     </x-back.alert>
                 @endif
 

--- a/resources/views/back/follows/form.blade.php
+++ b/resources/views/back/follows/form.blade.php
@@ -18,9 +18,9 @@
                 <x-back.validation-errors :errors="$errors" />
 
                 @if(session('ok'))
-                    <x-back.alert 
+                    <x-back.alert
                         type='success'
-                        title="{!! session('ok') !!}">
+                        title="{{ session('ok') }}">
                     </x-back.alert>
                 @endif
 

--- a/resources/views/back/pages/form.blade.php
+++ b/resources/views/back/pages/form.blade.php
@@ -18,9 +18,9 @@
                 <x-back.validation-errors :errors="$errors" />
 
                 @if(session('ok'))
-                    <x-back.alert 
+                    <x-back.alert
                         type='success'
-                        title="{!! session('ok') !!}">
+                        title="{{ session('ok') }}">
                     </x-back.alert>
                 @endif
 

--- a/resources/views/back/posts/form.blade.php
+++ b/resources/views/back/posts/form.blade.php
@@ -27,9 +27,9 @@ action="{{ Route::currentRouteName() === 'posts.edit' ? route('posts.update', $p
                 <x-back.validation-errors :errors="$errors" />
 
                 @if(session('ok'))
-                    <x-back.alert 
+                    <x-back.alert
                         type='success'
-                        title="{!! session('ok') !!}">
+                        title="{{ session('ok') }}">
                     </x-back.alert>
                 @endif
 

--- a/resources/views/back/users/form.blade.php
+++ b/resources/views/back/users/form.blade.php
@@ -14,9 +14,9 @@
                 <x-back.validation-errors :errors="$errors" />
 
                 @if(session('ok'))
-                    <x-back.alert 
+                    <x-back.alert
                         type='success'
-                        title="{!! session('ok') !!}">
+                        title="{{ session('ok') }}">
                     </x-back.alert>
                 @endif
 

--- a/resources/views/front/index.blade.php
+++ b/resources/views/front/index.blade.php
@@ -20,7 +20,7 @@
             <ul class="s-hero__social-icons">
             @foreach($follows as $follow)
                 <li>
-                    <a href="{{ $follow->href }}" target="_blank" >
+                    <a href="{{ $follow->href }}" target="_blank" rel="noopener noreferrer">
                         <i 
                             class="fab fa-{{ $follow->title === 'Facebook' ? 'facebook-f' : lcfirst($follow->title) }}" 
                             aria-hidden="true">

--- a/resources/views/front/layout.blade.php
+++ b/resources/views/front/layout.blade.php
@@ -235,7 +235,7 @@
     
                     <ul>
                         @foreach($follows as $follow)
-                            <li><a href="{{ $follow->href }}" target="_blank">{{ $follow->title }}</a></li>
+                            <li><a href="{{ $follow->href }}" target="_blank" rel="noopener noreferrer">{{ $follow->title }}</a></li>
                         @endforeach
                     </ul>
     


### PR DESCRIPTION
## Summary
- escape success alerts in admin forms
- add `rel="noopener noreferrer"` to external links

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445c1c5824832786e257da490b5247